### PR TITLE
Add Head texture and CustomModelData to Action Confirm GUI confirm utilities

### DIFF
--- a/src/main/java/fr/florianpal/fauction/configurations/gui/AuctionConfirmGuiConfig.java
+++ b/src/main/java/fr/florianpal/fauction/configurations/gui/AuctionConfirmGuiConfig.java
@@ -50,7 +50,11 @@ public class AuctionConfirmGuiConfig extends AbstractGuiConfig {
                 );
                 barrierBlocks.add(barrier);
             } else if (config.getString("block." + index + ".utility").equalsIgnoreCase("confirm")) {
-                confirmBlocks.put(Integer.valueOf(index), new Confirm(null,  Material.getMaterial(config.getString("block." + index + ".material")), config.getBoolean("block." + index + ".value")));
+                confirmBlocks.put(Integer.valueOf(index), new Confirm(null,
+                        Material.getMaterial(config.getString("block." + index + ".material")),
+                        config.getBoolean("block." + index + ".value"),
+                        config.getString("block." + index + ".texture", ""),
+                        config.getInt("block." + index + ".customModelData", 0)));
             }
         }
     }

--- a/src/main/java/fr/florianpal/fauction/gui/subGui/AuctionConfirmGui.java
+++ b/src/main/java/fr/florianpal/fauction/gui/subGui/AuctionConfirmGui.java
@@ -10,6 +10,7 @@ import fr.florianpal.fauction.objects.Auction;
 import fr.florianpal.fauction.objects.Barrier;
 import fr.florianpal.fauction.objects.Confirm;
 import fr.florianpal.fauction.utils.FormatUtil;
+import fr.florianpal.fauction.utils.PlayerHeadUtil;
 import net.milkbowl.vault.economy.EconomyResponse;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -55,7 +56,11 @@ public class AuctionConfirmGui extends AbstractGui implements GuiInterface {
 
         int id = 0;
         for (Map.Entry<Integer, Confirm> entry : auctionConfirmConfig.getConfirmBlocks().entrySet()) {
-            Confirm confirm = new Confirm(this.auction, entry.getValue().getMaterial(), entry.getValue().isValue());
+            Confirm confirm = new Confirm(this.auction,
+                    entry.getValue().getMaterial(),
+                    entry.getValue().isValue(),
+                    entry.getValue().getTexture(),
+                    entry.getValue().getCustomModelData());
             confirmList.put(entry.getKey(), confirm);
             inv.setItem(entry.getKey(), createGuiItem(confirm));
             id++;
@@ -73,6 +78,7 @@ public class AuctionConfirmGui extends AbstractGui implements GuiInterface {
         } else {
             title = auctionConfirmConfig.getTitleFalse();
         }
+
 
         DecimalFormat df = new DecimalFormat();
         df.setMaximumFractionDigits(2);
@@ -112,7 +118,12 @@ public class AuctionConfirmGui extends AbstractGui implements GuiInterface {
         if (meta != null) {
             meta.setDisplayName(title);
             meta.setLore(listDescription);
+            meta.setCustomModelData(confirm.getCustomModelData());
             item.setItemMeta(meta);
+        }
+        if (confirm.getMaterial() == Material.PLAYER_HEAD) {
+            PlayerHeadUtil.addTexture(itemStack, confirm.getTexture());
+            itemStack.setAmount(1);
         }
         return item;
     }

--- a/src/main/java/fr/florianpal/fauction/objects/Confirm.java
+++ b/src/main/java/fr/florianpal/fauction/objects/Confirm.java
@@ -8,11 +8,17 @@ public class Confirm {
 
     private Material material;
 
+    private final String texture;
+
+    private final int customModelData;
+
     private final boolean value;
 
-    public Confirm(Auction auction, Material material, boolean value) {
+    public Confirm(Auction auction, Material material, boolean value, String texture, int customModelData) {
         this.auction = auction;
         this.material = material;
+        this.texture = texture;
+        this.customModelData = customModelData;
         this.value = value;
     }
 
@@ -34,5 +40,13 @@ public class Confirm {
 
     public boolean isValue() {
         return value;
+    }
+
+    public String getTexture() {
+        return texture;
+    }
+
+    public int getCustomModelData() {
+        return customModelData;
     }
 }


### PR DESCRIPTION
Hi. Noticed that there are no way to configure CustomModelData for confirm utility in auctionConfirm menu.  So there is my solution